### PR TITLE
Allow clone with fine-grained token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "satellite"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Tom Young" },
 ]

--- a/satellite/main.py
+++ b/satellite/main.py
@@ -19,8 +19,11 @@ from satellite._tables import Tables
 from satellite._settings import EnvVar
 from satellite._utils import call_every_n_seconds
 
-REPO_URI = "github.com/UCLH-Foundry/Inform-DB"
 PAT = EnvVar("INFORMDB_PAT").unwrap()
+if PAT.startswith("github_pat"):  # is a fine-grained token
+    REPO_URL = f"https://oauth2:{PAT}@github.com/UCLH-Foundry/Inform-DB"
+else:
+    REPO_URL = f"https://{PAT}:x-oauth-basic@github.com/UCLH-Foundry/Inform-DB"
 
 star = DatabaseSchema(
     name=EnvVar("STAR_SCHEMA_NAME").or_default(),
@@ -29,7 +32,7 @@ star = DatabaseSchema(
     username=EnvVar("POSTGRES_USER").unwrap(),
     password=EnvVar("POSTGRES_PASSWORD").unwrap(),
     tables=Tables.from_repo(
-        repo_url=f"https://{PAT}:x-oauth-basic@{REPO_URI}",
+        repo_url=REPO_URL,
         branch_name=EnvVar("INFORMDB_BRANCH_NAME").or_default(),
     ),
 )


### PR DESCRIPTION
New fine-grained tokens require a different format than classic ones, both are now supported. See https://stackoverflow.com/questions/74532852/github-clone-repo-with-fine-grained-personal-access-tokens-pat 