### PR TITLE
Fix pg ready but no schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,12 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i '/en_GB.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 
-# Download the tagged version of the Satellite repo if it is set otherwise use the current dir
+# Install package
 COPY . /Satellite
 
-RUN if [ "$TAG" != "" ] ; then \
+RUN if [ -d "/Satellite/satellite" ] ; then \
+      echo "Found satellite package. Not cloning"; \
+    else \
       echo "Cloning Satellite repo on: $TAG" && \
       rm -rf /Satellite && \
       git clone --depth 1 --branch ${TAG} https://github.com/UCLH-DIF/Satellite.git ;\

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@
 
 /usr/local/bin/docker-entrypoint.sh postgres &
 
-while pg_isready -U "${POSTGRES_USER:?}" ; ret=$? ; [ $ret -ne 0 ]; do
+while [ "$(satellite schema-exists)" = "False" ]; do
   sleep 1 # second
 done
 

--- a/satellite/main.py
+++ b/satellite/main.py
@@ -136,3 +136,8 @@ def continuously_delete() -> None:
             star.delete(table.random_existing_row())
 
     call_every_n_seconds(delete, num_seconds=time_delay)
+
+
+@cli.command()
+def schema_exists() -> None:
+    return print(star.exists)


### PR DESCRIPTION
When large tables are being inserted `pg_isready` can return 'true' but the schema to run the continual inserts into doesn't. This PR adds a `schema-exists` CLI command and uses that instead.

Drive by: Don't require the hidden `TAG=""` option when building the container in the root of the repository where satellite exist, for more intuitive local builds.